### PR TITLE
POD-823: Add repo cache

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,9 @@ Dockerless is a tool that allows you to build and run Docker containers without 
 
 ## Installation
 
-For example, to build an image:
+WARN: running dockerless on your host can delete key files and destroy your working environment.
+
+For example, to build an image, run the following in the gcr.io/kaniko-project/executor image:
 
 ``` bash
 dockerless build --dockerfile Dockerfile --context .
@@ -19,4 +21,14 @@ And to run a container:
 
 ``` bash
 dockerless start
+```
+
+## Development
+
+Build dockerless and new image
+
+```bash
+just build
+cp dist/dockerless_{arch}/dockerless .
+docker build -t {repo}/dockerless:{tag} -f Dockerfile --build-arg TARGETARCH=$(uname -m) --build-arg TARGETOS=linux .
 ```

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -45,7 +45,7 @@ func NewBuildCmd() *cobra.Command {
 	cobraCmd.Flags().StringArrayVar(&cmd.BuildArgs, "build-arg", []string{}, "Docker build args.")
 	cobraCmd.Flags().StringArrayVar(&cmd.IgnorePaths, "ignore-path", []string{}, "Extra paths to exclude from deletion.")
 	cobraCmd.Flags().BoolVar(&cmd.Insecure, "insecure", true, "If true will not check for certificates")
-	cobraCmd.Flags().StringVar(&cmd.Registry, "registry-cache", "gcr.io/pascal-project-387807/my-dev-env", "Registry to use as remote cache.")
+	cobraCmd.Flags().StringVar(&cmd.Registry, "registry-cache", "", "Registry to use as remote cache.")
 	return cobraCmd
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -23,9 +23,9 @@ type BuildCmd struct {
 	Target    string
 	BuildArgs []string
 
-	IgnorePaths   []string
-	Insecure      bool
-	RegistryCache string
+	IgnorePaths []string
+	Insecure    bool
+	Registry    string
 }
 
 // NewBuildCmd returns a new build command
@@ -47,7 +47,7 @@ func NewBuildCmd() *cobra.Command {
 	cobraCmd.Flags().StringArrayVar(&cmd.BuildArgs, "build-arg", []string{}, "Docker build args.")
 	cobraCmd.Flags().StringArrayVar(&cmd.IgnorePaths, "ignore-path", []string{}, "Extra paths to exclude from deletion.")
 	cobraCmd.Flags().BoolVar(&cmd.Insecure, "insecure", true, "If true will not check for certificates")
-	cobraCmd.Flags().StringVar(&cmd.RegistryCache, "registry-cache", "gcr.io/pascal-project-387807/my-dev-env", "Registry to use as remote cache.")
+	cobraCmd.Flags().StringVar(&cmd.Registry, "registry-cache", "gcr.io/pascal-project-387807/my-dev-env", "Registry to use as remote cache.")
 	return cobraCmd
 }
 
@@ -159,8 +159,8 @@ func (cmd *BuildCmd) build() (v1.Image, error) {
 			CacheTTL: time.Hour * 24 * 7,
 		},
 	}
-	if cmd.RegistryCache != "" {
-		opts.CacheRepo = cmd.RegistryCache
+	if cmd.Registry != "" {
+		opts.CacheRepo = cmd.Registry
 	} else {
 		opts.CacheOptions.CacheDir = "/.dockerless/cache"
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,8 +24,8 @@ type BuildCmd struct {
 	BuildArgs []string
 
 	IgnorePaths []string
-	Insecure    bool
 	Registry    string
+	Insecure    bool
 }
 
 // NewBuildCmd returns a new build command

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,14 +17,12 @@ import (
 var ImageConfigOutput = "/.dockerless/image.json"
 
 type BuildCmd struct {
-	Dockerfile string
-	Context    string
-
-	Target    string
-	BuildArgs []string
-
-	IgnorePaths []string
+	Dockerfile  string
+	Context     string
+	Target      string
 	Registry    string
+	BuildArgs   []string
+	IgnorePaths []string
 	Insecure    bool
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -14,17 +14,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const DEFAULT_CACHE_DIR = "/.dockerless/cache"
+
 var ImageConfigOutput = "/.dockerless/image.json"
 
 type BuildCmd struct {
-	Dockerfile  string
-	Context     string
-	Target      string
-	Registry    string
-	BuildArgs   []string
-	IgnorePaths []string
-	Insecure    bool
-	ExportCache bool
+	Dockerfile    string
+	Context       string
+	Target        string
+	RegistryCache string
+	BuildArgs     []string
+	IgnorePaths   []string
+	Insecure      bool
+	ExportCache   bool
 }
 
 // NewBuildCmd returns a new build command
@@ -46,7 +48,7 @@ func NewBuildCmd() *cobra.Command {
 	cobraCmd.Flags().StringArrayVar(&cmd.BuildArgs, "build-arg", []string{}, "Docker build args.")
 	cobraCmd.Flags().StringArrayVar(&cmd.IgnorePaths, "ignore-path", []string{}, "Extra paths to exclude from deletion.")
 	cobraCmd.Flags().BoolVar(&cmd.Insecure, "insecure", true, "If true will not check for certificates")
-	cobraCmd.Flags().StringVar(&cmd.Registry, "registry-cache", "", "Registry to use as remote cache.")
+	cobraCmd.Flags().StringVar(&cmd.RegistryCache, "registry-cache", "", "Registry to use as remote cache.")
 	cobraCmd.Flags().BoolVar(&cmd.ExportCache, "export-cache", false, "If true kanoiko build push cache to registry.")
 	return cobraCmd
 }
@@ -161,10 +163,10 @@ func (cmd *BuildCmd) build() (v1.Image, error) {
 			CacheTTL: time.Hour * 24 * 7,
 		},
 	}
-	if cmd.Registry != "" {
-		opts.CacheRepo = cmd.Registry
+	if cmd.RegistryCache != "" {
+		opts.CacheRepo = cmd.RegistryCache
 	} else {
-		opts.CacheOptions.CacheDir = "/.dockerless/cache"
+		opts.CacheOptions.CacheDir = DEFAULT_CACHE_DIR
 	}
 	if !cmd.ExportCache {
 		opts.SingleSnapshot = true

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const DEFAULT_CACHE_DIR = "/.dockerless/cache"
+const defaultCacheDir = "/.dockerless/cache"
 
 var ImageConfigOutput = "/.dockerless/image.json"
 
@@ -166,7 +166,7 @@ func (cmd *BuildCmd) build() (v1.Image, error) {
 	if cmd.RegistryCache != "" {
 		opts.CacheRepo = cmd.RegistryCache
 	} else {
-		opts.CacheOptions.CacheDir = DEFAULT_CACHE_DIR
+		opts.CacheOptions.CacheDir = defaultCacheDir
 	}
 	if !cmd.ExportCache {
 		opts.SingleSnapshot = true


### PR DESCRIPTION
This PR introduces a new CLI parameter `--registry-cache` to toggle the kaniko builder's cache from a local directory to a registry.

Testing on my local kind cluster I have run through two workflows, after building devpod's `examples/build` (see https://github.com/loft-sh/devpod/pull/1245):

1. Adding a devcontainer.json feature (docker in docker)
- With cache: 3m21s
- Without cache: 7m36s

2. Changing build context (adding files to examples/build/app and adding RUN layer to Dockerfile)
- With cache: 3m13s
- Without cache: 7m46s

As you can see the remote cache has managed to save a user 50% build time when building updates to an existing image. Unfortunately the overall build time is still not great and this is a known issue - https://github.com/GoogleContainerTools/kaniko/issues/875

We could switch to docker in docker, but this comes with security concerns since we will need priv permissions to access the daemon.sock :/

EDIT: Some users report http2 being the cause, https://github.com/GoogleContainerTools/kaniko/issues/2751. I will try implement this and see if it improves build time.